### PR TITLE
Add installer-name in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,20 +19,17 @@
 			"role" : "Developer"
 		}
 	],
-    "minimum-stability": "dev",
+	"minimum-stability": "dev",
 	"require": {
 		"php"                : ">=5.3.0",
 		"composer/installers": "1.*,>=1.0.1"
 	},
-    "require-dev": {
-
-    },
-    "scripts": {
-
-    },
 	"autoload"   : {
 		"files": [
 			"IDProvider.php"
 		]
+	},
+	"extra": {
+		"installer-name": "IDProvider"
 	}
 }


### PR DESCRIPTION
Unless a `extra.installer-name` is specified this extension will be installed as `IdProvider` instead of `IDProvider`.