### PR TITLE
Updated function calls in IdProviderFactory to new versions 

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -11,7 +11,7 @@
 	"license-name": "MIT",
 	"type": "other",
 	"requires": {
-		"MediaWiki": ">= 1.31"
+		"MediaWiki": ">= 1.37"
 	},
 	"AutoloadNamespaces": {
 		"MediaWiki\\Extension\\IdProvider\\": "src/"

--- a/extension.json
+++ b/extension.json
@@ -11,7 +11,7 @@
 	"license-name": "MIT",
 	"type": "other",
 	"requires": {
-		"MediaWiki": ">= 1.37"
+		"MediaWiki": ">= 1.31"
 	},
 	"AutoloadNamespaces": {
 		"MediaWiki\\Extension\\IdProvider\\": "src/"

--- a/src/IdProviderFactory.php
+++ b/src/IdProviderFactory.php
@@ -46,7 +46,7 @@ class IdProviderFactory {
 		return function ( $action ) {
 			$factory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
 			$mainLB = $factory->getMainLB();
-			$dbw = $mainLB->getConnectionRef( DB_MASTER );
+			$dbw = $mainLB->getConnectionRef( DB_PRIMARY );
 			$factory->beginPrimaryChanges( __METHOD__ );
 			$result = $action( $dbw );
 			$factory->commitPrimaryChanges( __METHOD__ );

--- a/src/IdProviderFactory.php
+++ b/src/IdProviderFactory.php
@@ -46,7 +46,7 @@ class IdProviderFactory {
 		return function ( $action ) {
 			$factory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
 			$mainLB = $factory->getMainLB();
-			$dbw = $mainLB->getConnectionRef( DB_PRIMARY );
+			$dbw = $mainLB->getConnection( DB_PRIMARY );
 			$factory->beginPrimaryChanges( __METHOD__ );
 			$result = $action( $dbw );
 			$factory->commitPrimaryChanges( __METHOD__ );

--- a/src/IdProviderFactory.php
+++ b/src/IdProviderFactory.php
@@ -44,6 +44,7 @@ class IdProviderFactory {
 
 	private static function dbExecute() {
 		return function ( $action ) {
+			global $wgVersion;
 			$factory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
 			$mainLB = $factory->getMainLB();
 			if ( version_compare( $wgVersion, '1.37', '<' ) ) {

--- a/src/IdProviderFactory.php
+++ b/src/IdProviderFactory.php
@@ -47,9 +47,9 @@ class IdProviderFactory {
 			$factory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
 			$mainLB = $factory->getMainLB();
 			$dbw = $mainLB->getConnectionRef( DB_MASTER );
-			$factory->beginMasterChanges( __METHOD__ );
+			$factory->beginPrimaryChanges( __METHOD__ );
 			$result = $action( $dbw );
-			$factory->commitMasterChanges( __METHOD__ );
+			$factory->commitPrimaryChanges( __METHOD__ );
 
 			return $result;
 		};

--- a/src/IdProviderFactory.php
+++ b/src/IdProviderFactory.php
@@ -46,12 +46,20 @@ class IdProviderFactory {
 		return function ( $action ) {
 			$factory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
 			$mainLB = $factory->getMainLB();
-			$dbw = $mainLB->getConnection( DB_PRIMARY );
-			$factory->beginPrimaryChanges( __METHOD__ );
-			$result = $action( $dbw );
-			$factory->commitPrimaryChanges( __METHOD__ );
-
-			return $result;
+			if ( version_compare( $wgVersion, '1.37', '<' ) ) {
+				$dbw = $mainLB->getConnectionRef( DB_MASTER );
+				$factory->beginMasterChanges( __METHOD__ );
+				$result = $action( $dbw );
+				$factory->commitMasterChanges( __METHOD__ );
+				return $result;
+			} else {
+				// in MediaWiki 1.37 and later, some functions were renamed and others deprecated
+				$dbw = $mainLB->getConnection( DB_PRIMARY );
+				$factory->beginPrimaryChanges( __METHOD__ );
+				$result = $action( $dbw );
+				$factory->commitPrimaryChanges( __METHOD__ );
+				return $result;
+			}
 		};
 	}
 


### PR DESCRIPTION
While working in a mediawiki version 1.38, I stumbled upon an error when saving a page with a template using IdProvider for generating a value. The error read `Exception caught: Call to undefined method Wikimedia\Rdbms\LBFactorySimple::beginMasterChanges()`. 
While debugging, I found that `beginMasterChanges()` and `commitMasterChanges()` were renamed in MediaWiki 1.37 an newer. Furthermore, I found a few more elements around that place that are deprecated in/for version 1.39

I changed the elements in the function `dbExecute()` of `IdProviderFactory` to the newer and not deprecated elements.
I tested only the renamed functions in a productive environment and verified that the error was fixed.