### PR TITLE
Issue 19 - call to undefined method WikiPage::factory()

### DIFF
--- a/src/IdProvider.php
+++ b/src/IdProvider.php
@@ -29,15 +29,15 @@ class IdProvider {
 	 * @var callable Function to decide if string ID already exists, i.e. is already used as a
 	 * WikiPage
 	 */
-	private $isUniqueId;
+	private $getUniqueIdChecker;
 
 	/**
 	 * @param $generator
-	 * @param null $isUniqueId
+	 * @param null $getUniqueIdChecker
 	 */
-	public function __construct( $generator, $isUniqueId = null ) {
+	public function __construct( $generator, $getUniqueIdChecker = null ) {
 		$this->generator = $generator;
-		$this->isUniqueId = $isUniqueId;
+		$this->getUniqueIdChecker = $getUniqueIdChecker;
 	}
 
 	public function getId( array $params = [] ): string {
@@ -47,7 +47,7 @@ class IdProvider {
 		$prefix = trim( $prefix );
 		$id = $prefix . $this->generator->generate();
 		if ( !$skipUniqueTest ) {
-			while ( !( $this->isUniqueId )( $id ) ) {
+			while ( !( $this->getUniqueIdChecker )( $id ) ) {
 				$id = $prefix . $this->generator->generate();
 			}
 		}

--- a/src/IdProviderFactory.php
+++ b/src/IdProviderFactory.php
@@ -67,8 +67,8 @@ class IdProviderFactory {
 	 *                  whether the WikiPage associated with the given title/ID exists or not.
 	 */
 	private static function getUniqueIdChecker() {
-		return function ( $text ) {
-			$title = Title::newFromText( $text );
+		return function ( $id ) {
+			$title = Title::newFromText( $id );
 			
 			// If no Title object is found, the page does not exist
 			if ( $title === null ) {

--- a/src/IdProviderFactory.php
+++ b/src/IdProviderFactory.php
@@ -59,18 +59,16 @@ class IdProviderFactory {
 	}
 
 	/**
-	 * Checks whether a WikiPage with the following id/title already exists
+	 * Function to check if string id/title already exists, i.e. is already used as a
+	 * WikiPage (if page already exists)
 	 *
+	 * @param string $text The title or ID to check for uniqueness of the wiki page.
 	 * @return \Closure
 	 */
 	private static function isUniqueId() {
-		return function ( $id ) {
-			// Determine if $id is numeric or a string
-			if ( is_numeric( $id ) ) {
-				$title = Title::newFromID( (int)$id );
-			} else {
-				$title = Title::newFromText( $id );
-			}
+		return function ( $text ) {
+			$title = Title::newFromText( $text );
+			
 			// If no Title object is found, the page does not exist
 			if ( $title === null ) {
 				return true;

--- a/src/IdProviderFactory.php
+++ b/src/IdProviderFactory.php
@@ -39,7 +39,7 @@ class IdProviderFactory {
 	}
 
 	private static function provider( $generator ) {
-		return new IdProvider( $generator, self::isUniqueId() );
+		return new IdProvider( $generator, self::getUniqueIdChecker() );
 	}
 
 	private static function dbExecute() {
@@ -65,7 +65,7 @@ class IdProviderFactory {
 	 * @param string $text The title or ID to check for uniqueness of the wiki page.
 	 * @return \Closure
 	 */
-	private static function isUniqueId() {
+	private static function getUniqueIdChecker() {
 		return function ( $text ) {
 			$title = Title::newFromText( $text );
 			

--- a/src/IdProviderFactory.php
+++ b/src/IdProviderFactory.php
@@ -59,11 +59,12 @@ class IdProviderFactory {
 	}
 
 	/**
-	 * Function to check if string id/title already exists, i.e. is already used as a
-	 * WikiPage (if page already exists)
+	 * Returns a closure that checks if a string ID or title is unique by verifying whether
+	 * the corresponding WikiPage already exists. The closure can be invoked later with a specific
+	 * title or ID to check for its uniqueness.
 	 *
-	 * @param string $text The title or ID to check for uniqueness of the wiki page.
-	 * @return \Closure
+	 * @return \Closure A closure that takes a string $text as input and returns a boolean indicating
+	 *                  whether the WikiPage associated with the given title/ID exists or not.
 	 */
 	private static function getUniqueIdChecker() {
 		return function ( $text ) {

--- a/src/IdProviderFactory.php
+++ b/src/IdProviderFactory.php
@@ -65,7 +65,16 @@ class IdProviderFactory {
 	 */
 	private static function isUniqueId() {
 		return function ( $id ) {
-			$title = Title::newFromText( $id );
+			// Determine if $id is numeric or a string
+			if ( is_numeric( $id ) ) {
+				$title = Title::newFromID( (int)$id );
+			} else {
+				$title = Title::newFromText( $id );
+			}
+			// If no Title object is found, the page does not exist
+			if ( $title === null ) {
+				return true;
+			}
 
 			// MW 1.36+
 			if ( method_exists( MediaWikiServices::class, 'getWikiPageFactory' ) ) {

--- a/tests/phpunit/Unit/IdProviderFactoryTest.php
+++ b/tests/phpunit/Unit/IdProviderFactoryTest.php
@@ -17,6 +17,7 @@ use MediaWiki\Extension\IdProvider\Generators\IncrementIdGenerator;
 use MediaWiki\Extension\IdProvider\Generators\UuidGenerator;
 use MediaWiki\Extension\IdProvider\IdProviderFactory;
 use PHPUnit\Framework\TestCase;
+use Title;
 
 /**
  * @group IDProvider
@@ -57,7 +58,27 @@ class IdProviderFactoryTest extends TestCase {
 		$reflection->setAccessible( true );
 		$isUniqueClosure = $reflection->invoke( null );
 	
-		$this->assertTrue( $isUniqueClosure( 'NewPage' ) );
+		// check when id/title is from the page which exists and return false when page already exists
+        $this->assertFalse( $isUniqueClosure( 'Main Page' ) );
+
+		// check when id/title is from the page which not exists and return true if page do not exists
+        $this->assertTrue( $isUniqueClosure( 'Non existing page' ) );
+	}
+
+	public function testGetUniqueIdCheckerWhenTitleIsMalformed() {	
+		// Call the private method using Reflection
+		$reflection = new \ReflectionMethod( IdProviderFactory::class, 'getUniqueIdChecker' );
+		$reflection->setAccessible( true );
+		$isUniqueClosure = $reflection->invoke( null );
+
+		$title = Title::newFromText( 'nonexisting title' );
+
+		// Asserts that an InvalidArgumentException is thrown and that message is good
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( '$text must be a string' );
+
+		// add object instead of string, it should thrown the InvalidArgumentException
+		$isUniqueClosure( $title );
 	}
 
 	public function testParamGet() {

--- a/tests/phpunit/Unit/IdProviderFactoryTest.php
+++ b/tests/phpunit/Unit/IdProviderFactoryTest.php
@@ -51,31 +51,13 @@ class IdProviderFactoryTest extends TestCase {
 		$this->assertEquals( IncrementIdGenerator::class, $provider->generatorClass() );
 	}
 
-	public function testIsUniqueIdWhenIdIsInteger() {	
-		// Call the private method using Reflection
-		$reflection = new \ReflectionMethod( IdProviderFactory::class, 'isUniqueId' );
-		$reflection->setAccessible( true );
-		$isUniqueClosure = $reflection->invoke( null );
-	
-		$this->assertFalse( $isUniqueClosure( 1 ) );
-	}
-
-	public function testIsUniqueIdWhenIdIsText() {	
+	public function testIsUniqueId() {	
 		// Call the private method using Reflection
 		$reflection = new \ReflectionMethod( IdProviderFactory::class, 'isUniqueId' );
 		$reflection->setAccessible( true );
 		$isUniqueClosure = $reflection->invoke( null );
 	
 		$this->assertTrue( $isUniqueClosure( 'NewPage' ) );
-	}
-
-	public function testIsUniqueIdWhenPageNotExists() {	
-		// Call the private method using Reflection
-		$reflection = new \ReflectionMethod( IdProviderFactory::class, 'isUniqueId' );
-		$reflection->setAccessible( true );
-		$isUniqueClosure = $reflection->invoke( null );
-	
-		$this->assertTrue( $isUniqueClosure( 10 ) );
 	}
 
 	public function testParamGet() {

--- a/tests/phpunit/Unit/IdProviderFactoryTest.php
+++ b/tests/phpunit/Unit/IdProviderFactoryTest.php
@@ -50,4 +50,42 @@ class IdProviderFactoryTest extends TestCase {
 		$provider = IdProviderFactory::increment();
 		$this->assertEquals( IncrementIdGenerator::class, $provider->generatorClass() );
 	}
+
+	public function testIsUniqueIdWhenIdIsInteger() {	
+		// Call the private method using Reflection
+		$reflection = new \ReflectionMethod( IdProviderFactory::class, 'isUniqueId' );
+		$reflection->setAccessible( true );
+		$isUniqueClosure = $reflection->invoke( null );
+	
+		$this->assertFalse( $isUniqueClosure( 1 ) );
+	}
+
+	public function testIsUniqueIdWhenIdIsText() {	
+		// Call the private method using Reflection
+		$reflection = new \ReflectionMethod( IdProviderFactory::class, 'isUniqueId' );
+		$reflection->setAccessible( true );
+		$isUniqueClosure = $reflection->invoke( null );
+	
+		$this->assertTrue( $isUniqueClosure( 'NewPage' ) );
+	}
+
+	public function testIsUniqueIdWhenPageNotExists() {	
+		// Call the private method using Reflection
+		$reflection = new \ReflectionMethod( IdProviderFactory::class, 'isUniqueId' );
+		$reflection->setAccessible( true );
+		$isUniqueClosure = $reflection->invoke( null );
+	
+		$this->assertTrue( $isUniqueClosure( 10 ) );
+	}
+
+	public function testParamGet() {
+		// Call the private method using Reflection
+		$reflection = new \ReflectionMethod( IdProviderFactory::class, 'paramGet' );
+		$reflection->setAccessible( true );
+	
+		$params = [ 'key' => 'value' ];
+	
+		$this->assertEquals( 'value', $reflection->invoke( null, $params, 'key', 'default' ) );
+		$this->assertEquals( 'default', $reflection->invoke( null, $params, 'missing_key', 'default' ) );
+	}
 }

--- a/tests/phpunit/Unit/IdProviderFactoryTest.php
+++ b/tests/phpunit/Unit/IdProviderFactoryTest.php
@@ -51,9 +51,9 @@ class IdProviderFactoryTest extends TestCase {
 		$this->assertEquals( IncrementIdGenerator::class, $provider->generatorClass() );
 	}
 
-	public function testIsUniqueId() {	
+	public function testGetUniqueIdChecker() {	
 		// Call the private method using Reflection
-		$reflection = new \ReflectionMethod( IdProviderFactory::class, 'isUniqueId' );
+		$reflection = new \ReflectionMethod( IdProviderFactory::class, 'getUniqueIdChecker' );
 		$reflection->setAccessible( true );
 		$isUniqueClosure = $reflection->invoke( null );
 	


### PR DESCRIPTION
This PR is related to the issue #19. 

This PR contains:

- method `isUniqueId()` updated, renamed to `getUniqueIdChecker()`
- increase codecov for `IdProviderFactory.php`, cover `getUniqueIdChecker()` function