### PR TITLE
deps(codesniffer): bump mediawiki-codesniffer from 45.0.0 to 48.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Phan static analysis, wired into CI as a dedicated step on the coverage matrix row.
 
+### Changed
+
+- Bumped `mediawiki/mediawiki-codesniffer` from 45.0.0 to 48.0.0, the highest version
+  compatible with the CI container's PHP 8.1, resolving new `ClassAnnotations`,
+  `CommentBeforeClass`, `PropertyDocumentation`, and `FunctionComment`/
+  `ClassDocumentation` sniff violations along the way.
+
 ### Fixed
 
 - Race condition in `IncrementIdGenerator::calculateIncrement()`: concurrent requests

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "composer/installers": "^2.3.0"
   },
   "require-dev": {
-    "mediawiki/mediawiki-codesniffer": "45.0.0",
+    "mediawiki/mediawiki-codesniffer": "48.0.0",
     "mediawiki/mediawiki-phan-config": "0.16.0",
     "mediawiki/minus-x": "1.1.3",
     "php-parallel-lint/php-console-highlighter": "1.0.0",

--- a/src/Generators/FakeIdGenerator.php
+++ b/src/Generators/FakeIdGenerator.php
@@ -16,7 +16,6 @@ namespace MediaWiki\Extension\IdProvider\Generators;
  * Generates a Fake ID that is very likely to be truly unique (no guarantee however!)
  *
  * This is achieved through mixing a milli-timestamp (php uniqid();) with a random string
- *
  */
 class FakeIdGenerator {
 

--- a/src/Generators/IncrementIdGenerator.php
+++ b/src/Generators/IncrementIdGenerator.php
@@ -69,7 +69,6 @@ class IncrementIdGenerator {
 	 *
 	 * @throws DBUnexpectedError
 	 * @throws Exception
-	 *
 	 */
 	private function calculateIncrement( string $prefix ) {
 		$fname = __METHOD__;

--- a/src/Generators/UuidGenerator.php
+++ b/src/Generators/UuidGenerator.php
@@ -16,7 +16,6 @@ namespace MediaWiki\Extension\IdProvider\Generators;
  * Returns a UUID, using openssl random bytes
  *
  * @see http://stackoverflow.com/a/15875555
- *
  */
 class UuidGenerator {
 

--- a/src/IdProvider.php
+++ b/src/IdProvider.php
@@ -22,7 +22,6 @@ use MediaWiki\Extension\IdProvider\Generators\UuidGenerator;
  * They can be used in a programmatic way through this class
  * Use the static getId function as the main entry point
  *
- * @file
  * @ingroup Extensions
  */
 class IdProvider {

--- a/tests/phpunit/Unit/IdProviderTest.php
+++ b/tests/phpunit/Unit/IdProviderTest.php
@@ -52,6 +52,7 @@ class IdProviderTest extends TestCase {
 	private static function generator( $ids ) {
 		return new class ( $ids ) {
 
+			/** @var array */
 			private $ids;
 
 			public function __construct( $ids ) {


### PR DESCRIPTION
## Summary
- Supersedes #51, which Dependabot could not recreate: composer's audit gate refuses to resolve the current `45.0.0` pin at all, since it requires `squizlabs/php_codesniffer` 3.10.3, affected by [GHSA-hmqg-cxww-wqhq](https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq).
- Bumps `mediawiki/mediawiki-codesniffer` to `48.0.0` — the highest release compatible with this repo's CI container (PHP 8.1). The latest release (`52.0.0`) requires PHP ≥8.3.
- Fixes the new sniff violations the updated ruleset surfaces (invalid `@file` class annotation, missing blank line between file-/class-level docblocks, missing property doc comment, trailing empty lines in 3 doc comments).
- Matches the version already used in sibling repos (`EditAccount`).

## Test plan
- [x] `make ci` (lint → phpcs → phan → phpunit → npm-test) passes locally
- [x] `composer update` resolves cleanly under PHP 8.1 without hitting the audit block